### PR TITLE
Add names to middlewares

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,67 @@
 const Router = require('express').Router;
 
-module.exports = (options) => {
+/**
+ * A helper for `createNamedAsyncMiddleware`
+ * If the function already has a name, we'll just use that and tack
+ * `Async` on the end. If the function doesn't have a name we'll
+ * use the path for the target handler plus the index of the current
+ * middleware.
+ */
+function getFunctionName(fun, handlerPath, middlewareIndex) {
+  if (fun.name) {
+    return fun.name + 'Async'
+  }
+
+  // Path can be a string, regex, or array of either
+  const strPath = handlerPath.toString();
+
+  return strPath + middlewareIndex;
+}
+
+/**
+ * Create a middleware which calls the original function but catches
+ * unhandled promise rejections (either from async functions or returned promise)
+ * and passes the error to `next` which will call the next error handler middleware.
+ *
+ * For better stack traces we want to make sure that the functions are
+ * named function for each middleware the simplest to have a dynamic
+ * function.name is to initialize it in an object with the key being
+ * the dynamic function name
+ */
+function createNamedAsyncMiddleware(fun, handlerPath, middlewareIndex) {
+  const functionName = getFunctionName(fun, handlerPath, middlewareIndex);
+
+  return {
+    [functionName]: (req, res, next) => {
+      // Execute the function
+      const p = fun(req, res, next);
+
+      // If the result isn't a promise
+      if (!p.then || !p.catch) {
+        console.error(
+          'Expected then handler for route %s to be async',
+          req.url,
+        );
+      }
+
+      // catch the error and pass it to the next error handling middleware
+      const pp = p.catch(next);
+      if (pp.done) {
+        // Terminate promise for bluebird and Q
+        pp.done();
+      }
+    },
+  }[functionName];
+}
+
+function createAsyncRouter(options) {
   const router = new Router(options);
 
   function createHandler(method) {
     return function handler(path, ...rest) {
-      const asyncRest = rest.map(fun => (req, res, next) => {
-        const p = fun(req, res, next);
-        if (!p.then || !p.catch) {
-          console.error(
-            'Expected then handler for route %s to be async',
-            req.url
-          );
-        }
-
-        const pp = p.catch(next);
-        if (pp.done) {
-          pp.done();
-        }
-      });
+      const asyncRest = rest.map((fun, i) =>
+        createNamedAsyncMiddleware(fun, path, i),
+      );
 
       return router[method](path, ...asyncRest);
     };
@@ -30,4 +73,6 @@ module.exports = (options) => {
   router.putAsync = createHandler('put');
 
   return router;
-};
+}
+
+module.exports = createAsyncRouter;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const Router = require('express').Router;
  * middleware.
  */
 function getFunctionName(fun, handlerPath, middlewareIndex) {
-  if (fun.name) {
+  if (fun.name && fun.name !== 'anonymous') {
     return fun.name + 'Async';
   }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const Router = require('express').Router;
  */
 function getFunctionName(fun, handlerPath, middlewareIndex) {
   if (fun.name) {
-    return fun.name + 'Async'
+    return fun.name + 'Async';
   }
 
   // Path can be a string, regex, or array of either
@@ -37,11 +37,14 @@ function createNamedAsyncMiddleware(fun, handlerPath, middlewareIndex) {
       const p = fun(req, res, next);
 
       // If the result isn't a promise
-      if (!p.then || !p.catch) {
+      if (!p || typeof p !== 'object' || !p.then || !p.catch) {
         console.error(
-          'Expected then handler for route %s to be async',
+          'Expected then middleware number %d for route %s to return a promise',
+          i,
           req.url,
         );
+
+        return;
       }
 
       // catch the error and pass it to the next error handling middleware


### PR DESCRIPTION
Currently all our middlewares that use the async router lose their names and become `anonymous`. In our APM traces this kinda looks bad, we have no idea which middlewares are which because most things are anonymous. 

![image](https://user-images.githubusercontent.com/1994028/106948035-14a50a80-66e0-11eb-95f3-91c1ff3d602a.png)

In this PR:
- Made sure we use named functions for all our passed middlewares
  - Middlewares that are named just use `Function.name` concatenated with `Async`
  - Middlewares with no name use the handler's path + the middleware index as a name
- Make sure we don't call `catch` on middlewares that don't return a promise.
- Added comments to code